### PR TITLE
fix(email-editor): suppress redundant `update` emit when toggling edi…

### DIFF
--- a/frontend/src/components/campManagement/contact/EmailEditor.vue
+++ b/frontend/src/components/campManagement/contact/EmailEditor.vue
@@ -441,7 +441,12 @@ function unwrapTemplateVariables(html: string): string {
 
 watch(
   () => attrs.disable as boolean | undefined,
-  (disabled) => editor.value?.setEditable(!disabled),
+  // `setEditable`'s `emitUpdate` defaults to `true` and unconditionally
+  // re-emits 'update' regardless of whether the doc actually changed —
+  // toggling editability isn't a content edit, so suppress it explicitly.
+  // Otherwise this clobbers `model` with the editor's current serialization
+  // (e.g. an empty doc becomes '<p></p>' instead of the '' it was reset to).
+  (disabled) => editor.value?.setEditable(!disabled, false),
 );
 
 async function onFieldClick() {

--- a/frontend/src/pages/campManagement/ContactPage.vue
+++ b/frontend/src/pages/campManagement/ContactPage.vue
@@ -138,6 +138,9 @@ useRealtimeCollection<Message>('message', {
 function onSent(template: Message) {
   // The create response already carries the recipients, so prepend optimistically.
   sentMessages.value = [template, ...(sentMessages.value ?? [])];
+  // Clear the reuse draft so the form's dirty check compares against the blank
+  // pristine state instead of the now-stale draft it was reset away from.
+  draft.value = null;
 }
 
 async function onResend(template: Message) {


### PR DESCRIPTION
…tability and reset stale draft after sending messages